### PR TITLE
Adding GitHub templates to facilitate contribution workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Report a bug
+title: ''
+labels: kind/bug
+assignees: ''
+---
+
+**Describe the bug**
+
+(Describe the problem clearly and concisely.)
+
+**Expected behavior**
+
+(Describe the expected behavior clearly and concisely.)
+
+**Actual behavior**
+
+(Describe the actual behavior clearly and concisely.)
+
+**Additional context**
+
+(Add any other context about the problem here.)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,11 @@
+---
+name: Documentation
+about: A generalized task to improve the documentation
+title: ''
+labels: area/documentation
+assignees: ''
+---
+
+**Description**
+
+(Describe the task here.)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request / Enhancement
+about: Request or propose a new recipe
+title: ''
+labels: kind/enhancement
+assignees: ''
+---
+
+**Description**
+
+(Describe the feature here.)
+
+**Implementation ideas**
+
+(If you have any implementation ideas, they can go here.)

--- a/.github/ISSUE_TEMPLATE/housekeeping.md
+++ b/.github/ISSUE_TEMPLATE/housekeeping.md
@@ -1,0 +1,15 @@
+---
+name: Housekeeping
+about: A generalized task or cleanup not associated with a bug report or enhancement
+title: ''
+labels: area/housekeeping
+assignees: ''
+---
+
+**Description**
+
+(Describe the task here.)
+
+**Implementation ideas**
+
+(If you have any implementation ideas, they can go here.)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Description
+
+Please include a summary of the change and which feature is added or issue is fixed. Please also include
+relevant motivation and context. List any dependencies that are required for this change.
+
+**NOTE**: If the PR is still a work in progress, and so is not ready to be merged, but needs to be pushed to
+facilitate review, then add `[WIP]` in the title. Optionally add the labels `work-in-progress` and `do-not-merge`.
+
+## GitHub Issue
+
+Please, if your PR is related with a GitHub issue, link here:
+
+- GitHub Issue Link
+
+## Checklist
+
+Please review this checklist before to open the PR to improve the review process:
+
+- [ ] The commit messages follow our guidelines
+- [ ] I have performed a self-review of my own changes
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have checked the documentation and corrected any misspellings
+
+## Other Information
+
+Please add other information needed to facilitate the review process to the reviewers.


### PR DESCRIPTION
This PR includes a set of GitHub templates to integrate with standards workflows, such as:

* Open issues (with different templates to classify the issue)
* Open Pull Request (adding some extra content and format to complete by the user)

These kind of templates are very common and useful in Open Source communities, and it could help to automate some tasks in the future.